### PR TITLE
Separated `get_trajectory` logic

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -212,7 +212,7 @@ class MoveIt2:
 
         # Flag to determine whether to execute trajectories via Move Group Action, or rather by calling
         # the separate ExecuteTrajectory action
-        # Applies to `move_to_pose()` and `move_to_configuraion()`
+        # Applies to `move_to_pose()` and `move_to_configuration()`
         self.__use_move_action = use_move_action
 
         # Store additional variables for later use
@@ -406,6 +406,19 @@ class MoveIt2:
         rate = self._node.create_rate(10)
         while not future.done():
             rate.sleep()
+
+        return self.get_trajectory(future, cartesian=cartesian)
+
+    def get_trajectory(self, future: Future, cartesian: bool = False) -> Optional[JointTrajectory]:
+        """
+        Takes in a future returned by plan_async and returns the trajectory if the future is done
+        and planning was successful, else None.
+        """
+        if (not future.done()):
+            self._node.get_logger().warn(
+                "Cannot get trajectory because future is not done."
+            )
+            return None
 
         res = future.result()
 


### PR DESCRIPTION
Previously, the logic to get a trajectory from the response to a planning service call was handled in the `plan` function. As a result, people who opt for `plan_async` instead would need to re-implement that logic. This PR breaks that logic off into its own function, so even people who directly call `plan_async` can get the trajectory.