### PR TITLE
Reset last error code before action execution

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -1102,6 +1102,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_move_action = self.__move_action_client.send_goal_async(
             goal=self.__move_action_goal,
@@ -1160,6 +1161,7 @@ class MoveIt2:
             )
             return
 
+        self.__last_error_code = None
         self.__is_motion_requested = True
         self.__send_goal_future_execute_trajectory = self.__execute_trajectory_action_client.send_goal_async(
             goal=goal,


### PR DESCRIPTION
Consider two cases, one where action server (either for execute or MoveGroup) is not available, and another where the action succeeds very fast. Both cases are currently indistinguishable from the client perspective, because they will request a goal, and then when they query the state it will be IDLE. This commit resolves that, because if the error code is set that means the action completed very fast, whereas if it is None that means the action did not complete. (Earlier that was not possible, because if the error code was set it was unclear whether it was set form the current action or the last action)