### PR TITLE
Allow different orientation tolerances per dimension

### DIFF
--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -672,8 +672,8 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
-        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
         weight: float = 1.0,
+        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.
@@ -871,8 +871,8 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
-        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
         weight: float = 1.0,
+        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
     ):
         """
         Set Cartesian orientation goal of `target_link` with respect to `frame_id`.

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -590,7 +590,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
     ):

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -671,7 +671,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
+        tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
     ):
         """
@@ -701,6 +701,10 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
+        if type(tolerance) == float:
+            tolerance_xyz = (tolerance, tolerance, tolerance)
+        else:
+            tolerance_xyz = tolerance
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
@@ -862,7 +866,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
+        tolerance: Union[float, Tuple[float, float, float]] = 0.001,
         weight: float = 1.0,
     ):
         """
@@ -892,9 +896,16 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
+        if type(tolerance) == float:
+            tolerance_xyz = (tolerance, tolerance, tolerance)
+        else:
+            tolerance_xyz = tolerance
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
+
+        # Define the parameterization (how to interpret the tolerance)
+        constraint.parameterization = 0 # 0: Euler Angles, 1: Rotation Vector
 
         # Set weight of the constraint
         constraint.weight = weight

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -671,7 +671,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance: float = 0.001,
+        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
         weight: float = 1.0,
     ):
         """
@@ -701,9 +701,9 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
-        constraint.absolute_x_axis_tolerance = tolerance
-        constraint.absolute_y_axis_tolerance = tolerance
-        constraint.absolute_z_axis_tolerance = tolerance
+        constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
+        constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
+        constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Set weight of the constraint
         constraint.weight = weight
@@ -862,7 +862,7 @@ class MoveIt2:
         quat_xyzw: Union[Quaternion, Tuple[float, float, float, float]],
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
-        tolerance: float = 0.001,
+        tolerance_xyz: Tuple[float, float, float] = [0.001, 0.001, 0.001],
         weight: float = 1.0,
     ):
         """
@@ -892,9 +892,9 @@ class MoveIt2:
             constraint.orientation.w = float(quat_xyzw[3])
 
         # Define tolerances
-        constraint.absolute_x_axis_tolerance = tolerance
-        constraint.absolute_y_axis_tolerance = tolerance
-        constraint.absolute_z_axis_tolerance = tolerance
+        constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
+        constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
+        constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Set weight of the constraint
         constraint.weight = weight

--- a/pymoveit2/moveit2.py
+++ b/pymoveit2/moveit2.py
@@ -388,7 +388,7 @@ class MoveIt2:
         joint_names: Optional[List[str]] = None,
         frame_id: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         tolerance_joint_position: float = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
@@ -454,7 +454,7 @@ class MoveIt2:
         joint_names: Optional[List[str]] = None,
         frame_id: Optional[str] = None,
         tolerance_position: float = 0.001,
-        tolerance_orientation: float = 0.001,
+        tolerance_orientation: Union[float, Tuple[float, float, float]] = 0.001,
         tolerance_joint_position: float = 0.001,
         weight_position: float = 1.0,
         weight_orientation: float = 1.0,
@@ -672,6 +672,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
+        parameterization: int = 0, # 0: Euler, 1: Rotation Vector
         weight: float = 1.0,
     ):
         """
@@ -708,6 +709,9 @@ class MoveIt2:
         constraint.absolute_x_axis_tolerance = tolerance_xyz[0]
         constraint.absolute_y_axis_tolerance = tolerance_xyz[1]
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
+
+        # Define parameterization (how to interpret the tolerance)
+        constraint.parameterization = parameterization
 
         # Set weight of the constraint
         constraint.weight = weight
@@ -867,6 +871,7 @@ class MoveIt2:
         frame_id: Optional[str] = None,
         target_link: Optional[str] = None,
         tolerance: Union[float, Tuple[float, float, float]] = 0.001,
+        parameterization: int = 0, # 0: Euler Angles, 1: Rotation Vector
         weight: float = 1.0,
     ):
         """
@@ -905,7 +910,7 @@ class MoveIt2:
         constraint.absolute_z_axis_tolerance = tolerance_xyz[2]
 
         # Define the parameterization (how to interpret the tolerance)
-        constraint.parameterization = 0 # 0: Euler Angles, 1: Rotation Vector
+        constraint.parameterization = parameterization
 
         # Set weight of the constraint
         constraint.weight = weight


### PR DESCRIPTION
In the earlier code, orientation constraints could only take in one tolerance that is equally applied to all three orientation dimensions. However, oftentimes we want different orientation tolerances per dimension, e.g., the robot must keep an object straight---low roll and pitch but any yaw. This change optionally allows users to pass in a 3-tuple to specify different orientation constraints per dimension. It also allows users to specify the parameterization to interpret those tolerances in: euler angles or rotation vector.